### PR TITLE
Futures support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,13 @@ Arguments:
 
 #. **path_dir_where_to_dump**:
     | (string) Path to folder where to dump the data
+#. **asset_class**:
+    | (string) Source of data: [spot, um, cm] um: usd(t) margined futures, cm: coin margined futures
 #. **data_type="klines"**:
-    | (string) data type to dump: [aggTrades, klines, trades]
+    | (string) data type to dump:
+    | [aggTrades, klines, trades] for spot
+    | [aggTrades, klines, trades, indexPriceKlines, markPriceKlines, premiumIndexKlines, metrics] for futures (metrics only supported for um)
+    | Refer to binance doc for additional info: https://github.com/binance/binance-public-data
 #. **str_data_frequency**:
     | (string) One of [1m, 3m, 5m, 15m, 30m, 1h, 2h, 4h, 6h, 8h, 12h]
     | Frequency of price-volume data candles to get

--- a/src/binance_historical_data/data_dumper.py
+++ b/src/binance_historical_data/data_dumper.py
@@ -416,7 +416,8 @@ class BinanceDataDumper:
                 ),
                 leave=False,
                 total=len(list_args),
-                desc=f"{timeperiod_per_file} files to download"
+                desc=f"{timeperiod_per_file} files to download",
+                unit="files"
             ))
         #####
         list_saved_dates = [date for date in list_saved_dates if date]
@@ -499,6 +500,7 @@ class BinanceDataDumper:
     @staticmethod
     def _download_raw_file(str_url_path_to_file, str_path_where_to_save):
         """Download file from binance server by URL"""
+
         LOGGER.debug("Download file from: %s", str_url_path_to_file)
         str_url_path_to_file = str_url_path_to_file.replace("\\", "/")
         try:
@@ -596,7 +598,6 @@ class BinanceDataDumper:
         """
         Create list of tickers for which to get data (by default all **USDT)
         """
-        LOGGER.info("Choose tickers to dump:")
         all_tickers = self.get_list_all_trading_pairs()
         LOGGER.info("---> Found overall tickers: %d", len(all_tickers))
 


### PR DESCRIPTION
Upgraded the tool to support futures data download + few upgrades:
- fetch available files on server to avoid 404 if an anterior start_date is entered
- tdqm progress bar for trades and aggtrades download as file are sometimes > 500MB

fix:
- reduced number of concurent threads to 10 to avoid connection blocking, or only one if we syncing trades