### PR TITLE
Hotfix/check latest downloaded monthly data

### DIFF
--- a/src/binance_historical_data/data_dumper.py
+++ b/src/binance_historical_data/data_dumper.py
@@ -170,7 +170,7 @@ class BinanceDataDumper:
                 # dumping data.
                 if latest_monthly_data_date != datetime.date.min:
                     if latest_monthly_data_date < monthly_end_date:
-                        date_start_daily = latest_monthly_data_date + relativedelta(days=1)
+                        date_start_daily = monthly_end_date + relativedelta(days=1)
                     else:
                         date_start_daily = date_end + relativedelta(days=1)
                 else:

--- a/src/binance_historical_data/data_dumper.py
+++ b/src/binance_historical_data/data_dumper.py
@@ -154,7 +154,7 @@ class BinanceDataDumper:
             else:
                 latest_monthly_data_date = self.get_latest_downloaded_date_for_ticker(ticker=ticker)
                 
-                if latest_monthly_data_date != datetime.MINYEAR and latest_monthly_data_date < date_end_first_day_of_month-relativedelta(days=1):
+                if latest_monthly_data_date != datetime.date.min and latest_monthly_data_date < date_end_first_day_of_month-relativedelta(days=1):
                     date_start_daily = latest_monthly_data_date + relativedelta(days=1)
                 else:
                     date_start_daily = date_end_first_day_of_month
@@ -230,7 +230,7 @@ class BinanceDataDumper:
     def get_latest_downloaded_date_for_ticker(self, ticker):
         """Get latest downloaded date for ticker"""
         path_folder_prefix = self._get_path_suffix_to_dir_with_data("monthly", ticker)
-        latest_date = datetime.MINYEAR
+        latest_date = datetime.date.min
         
         try:
             files = self._get_list_all_available_files(prefix=path_folder_prefix)
@@ -244,7 +244,7 @@ class BinanceDataDumper:
         except Exception as e:
             LOGGER.error('Latest date not found: ', e)
         
-        if latest_date == datetime.MINYEAR:
+        if latest_date == datetime.date.min:
             return latest_date
         return latest_date + relativedelta(months=1) - relativedelta(days=1)
     

--- a/src/binance_historical_data/data_dumper.py
+++ b/src/binance_historical_data/data_dumper.py
@@ -139,23 +139,20 @@ class BinanceDataDumper:
         for ticker in tqdm(list_trading_pairs, leave=True, desc="Tickers"):
             # 1) Download all monthly data
             # Monthly data will not be available for current month; Retrieve up till previous month if end date is in current month
-            # Otherwise no changes to end_date; Note: if end date resides in an available monthly data, monthly data will be downloaded instead
+            # Otherwise no changes to end_date; 
+            # Note: if end date resides in an available monthly data, monthly data will be downloaded instead
             # of multiple daily data.
+            
+            monthly_end_date = date_end
             if self._data_type != "metrics":
                 if (date_end.year == datetime.datetime.now(datetime.timezone.utc).year and date_end.month == datetime.datetime.now(datetime.timezone.utc).month) \
                     (date_end_first_day_of_month - relativedelta(days=1) > date_start):
-                    self._download_data_for_1_ticker(
+                    monthly_end_date = date_end_first_day_of_month - relativedelta(days=1)
+                    
+                self._download_data_for_1_ticker(
                         ticker=ticker,
                         date_start=date_start,
-                        date_end=(date_end_first_day_of_month - relativedelta(days=1)),
-                        timeperiod_per_file="monthly",
-                        is_to_update_existing=is_to_update_existing,
-                    )
-                else: 
-                    self._download_data_for_1_ticker(
-                        ticker=ticker,
-                        date_start=date_start,
-                        date_end=date_end,
+                        date_end=monthly_end_date,
                         timeperiod_per_file="monthly",
                         is_to_update_existing=is_to_update_existing,
                     )
@@ -172,7 +169,7 @@ class BinanceDataDumper:
                 # otherwise, we will simply set start date to a day after and do a bounds check before
                 # dumping data.
                 if latest_monthly_data_date != datetime.date.min:
-                    if latest_monthly_data_date < date_end_first_day_of_month-relativedelta(days=1):
+                    if latest_monthly_data_date < monthly_end_date:
                         date_start_daily = latest_monthly_data_date + relativedelta(days=1)
                     else:
                         date_start_daily = date_end + relativedelta(days=1)


### PR DESCRIPTION
To circumvent delays in monthly data upload.

1. Retrieve the latest downloaded monthly data date from downloaded file, work out the last day of the month and compare against requested monthly data end date.
2. If latest downloaded monthly data date is earlier, that means the previous month's monthly data is not available yet, we include it in the daily data downloads

This resolves issues #30